### PR TITLE
Quote space fix.

### DIFF
--- a/core/src/main/scala/records/Macros.scala
+++ b/core/src/main/scala/records/Macros.scala
@@ -145,8 +145,8 @@ object Macros {
         case (acc, e) => q"""$acc + ", " + $e"""
       }
 
-      val str = cont.fold[Tree](q""""Rec {}"""") { cont =>
-        q""""Rec { " + $cont + " }""""
+      val str = cont.fold[Tree](q""" "Rec {}" """) { cont =>
+        q""" "Rec { " + $cont + " }" """
       }
 
       q"override def toString(): String = $str"


### PR DESCRIPTION
Sublime Text now correctly highlights text in Macros.scala
