### PR TITLE
Support current Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,14 @@ branches:
     - record-operations
 matrix:
   include:
-  - scala: 2.12.0-RC1
+  - scala: 2.12.0
+    jdk: oraclejdk8
+  include:
+  - scala: 2.12.1
+    jdk: oraclejdk8
+  include:
+  - scala: 2.12.2
+    jdk: oraclejdk8
+  include:
+  - scala: 2.12.3
     jdk: oraclejdk8

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -48,13 +48,11 @@ object BuildSettings {
       "2.10.2", "2.10.3", "2.10.4",
       "2.11.0", "2.11.1", "2.11.2",
       "2.11.3", "2.11.4", "2.11.5",
-      "2.11.6", "2.12.0-RC1", "2.12.0-SNAPSHOT"),
+      "2.11.6", "2.12.0", "2.12.1",
+      "2.12.2", "2.12.3"),
     resolvers += Resolver.sonatypeRepo("snapshots"),
     libraryDependencies += {
-      if (scalaVersion.value == "2.12.0-SNAPSHOT")
-        "org.scalatest" % "scalatest_2.12" % "3.0.0" % "test"
-      else
-        "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+      "org.scalatest" %% "scalatest" % "3.0.0" % "test"
     },
     ScalariformKeys.preferences in Compile := formattingPreferences,
     ScalariformKeys.preferences in Test    := formattingPreferences

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16


### PR DESCRIPTION
I wanted to be able to use records in one project of mine that uses 2.12.3

- Remove 2.12.0-RC1 instances; include 2.12.{0..3}
- Add an explicit sbt version of 0.13.16 since this doesn't run with new sbt 1.0 which no longer has features used by this build.